### PR TITLE
Fix grid layout when all items fit in one row

### DIFF
--- a/ImGuiWidgets/Grid.cs
+++ b/ImGuiWidgets/Grid.cs
@@ -97,6 +97,8 @@ public static partial class ImGuiWidgets
 					numColumns--;
 					break;
 				}
+				// Once we have iterated all items without exceeding the contentRegionAvailable.X we
+				// want to break without incrementing the number of columns because the content will fit
 				else if (numColumns == itemList.Length)
 				{
 					break;

--- a/ImGuiWidgets/Grid.cs
+++ b/ImGuiWidgets/Grid.cs
@@ -97,6 +97,10 @@ public static partial class ImGuiWidgets
 					numColumns--;
 					break;
 				}
+				else if (numColumns == itemList.Length)
+				{
+					break;
+				}
 				numColumns++;
 			}
 


### PR DESCRIPTION
Fix for grid layout when all items can fit on a single line. The outermost loop will only stop when the number of columns is greater than the number of items (while (numColumns <= itemList.Length)), this can't be changed to a less than check because we need to iterate at least itemList.Length number of times in case the last element in the list doesn't fit and we need to reduce the number of columns (eg. If it was changed to a less than check we wouldn't be including the last column in the calculation correctly).

Add a check for if we just dealt with the last item AFTER checking if the width fits. If the width is fine and this was the last item then we don't need to add another column and can break immediately, causing the sizing to be correct.