### PR TITLE
Add grid and icon visual debugging

### DIFF
--- a/ImGuiWidgets/Grid.cs
+++ b/ImGuiWidgets/Grid.cs
@@ -8,6 +8,7 @@ using ImGuiNET;
 /// </summary>
 public static partial class ImGuiWidgets
 {
+	public static bool EnableGridDebugDraw { get; set; } = true;
 	public enum GridOrder
 	{
 		// Items are displayed in order left to right before dropping to the next row
@@ -214,6 +215,13 @@ public static partial class ImGuiWidgets
 
 				if (itemIndex < itemList.Length)
 				{
+					if (EnableGridDebugDraw)
+					{
+						uint borderColor = ImGui.GetColorU32(ImGui.GetStyle().Colors[(int)ImGuiCol.Border]);
+						var drawList = ImGui.GetWindowDrawList();
+						drawList.AddRect(itemStartCursor, itemStartCursor + cellSize, ImGui.GetColorU32(borderColor));
+					}
+
 					drawDelegate(itemList[itemIndex], cellSize, itemDimensions[itemIndex]);
 				}
 

--- a/ImGuiWidgets/Grid.cs
+++ b/ImGuiWidgets/Grid.cs
@@ -81,18 +81,18 @@ public static partial class ImGuiWidgets
 				switch (gridOrder)
 				{
 					case GridOrder.RowMajor:
-					float rowWidth = 0f;
+						float rowWidth = 0f;
 
-					for (int i = 0; i < itemList.Length; i++)
-					{
-						if (i % numColumns == 0)
+						for (int i = 0; i < itemList.Length; i++)
 						{
-							rowWidth = 0f;
-						}
+							if (i % numColumns == 0)
+							{
+								rowWidth = 0f;
+							}
 
-						rowWidth += itemDimensions[i].X + itemSpacing.X;
-						maxRowWidth = Math.Max(maxRowWidth, rowWidth);
-					}
+							rowWidth += itemDimensions[i].X + itemSpacing.X;
+							maxRowWidth = Math.Max(maxRowWidth, rowWidth);
+						}
 						break;
 
 					case GridOrder.ColumnMajor:
@@ -104,7 +104,7 @@ public static partial class ImGuiWidgets
 							{
 								maxRowWidth += colItems.Max(item => item.X) + itemSpacing.X;
 							}
-				}
+						}
 						break;
 
 					default:

--- a/ImGuiWidgets/Grid.cs
+++ b/ImGuiWidgets/Grid.cs
@@ -8,6 +8,21 @@ using ImGuiNET;
 /// </summary>
 public static partial class ImGuiWidgets
 {
+	public enum GridOrder
+	{
+		// Items are displayed in order left to right before dropping to the next row
+		// Recommended for when displaying grids of icons
+		// [1] [2] [3]
+		// [4] [5] [6]
+		RowMajor,
+		// Items are displayed top to bottom before moving to the next column
+		// Note: Only 1 row may show 1 missing item. All other rows will be full.
+		// Recommended when displaying tables of data
+		// [1] [3] [5]
+		// [2] [4] [6]
+		ColumnMajor,
+	}
+
 	/// <summary>
 	/// Delegate to measure the size of a grid cell.
 	/// </summary>
@@ -32,8 +47,9 @@ public static partial class ImGuiWidgets
 	/// <param name="items">The items to be displayed in the grid.</param>
 	/// <param name="measureDelegate">The delegate to measure the size of each item.</param>
 	/// <param name="drawDelegate">The delegate to draw each item.</param>
-	public static void Grid<T>(IEnumerable<T> items, MeasureGridCell<T> measureDelegate, DrawGridCell<T> drawDelegate) =>
-		GridImpl.Show(items, measureDelegate, drawDelegate);
+	/// <param name="gridOrder">What ordering should grid items use</param>
+	public static void Grid<T>(IEnumerable<T> items, MeasureGridCell<T> measureDelegate, DrawGridCell<T> drawDelegate, GridOrder gridOrder) =>
+		GridImpl.Show(items, measureDelegate, drawDelegate, gridOrder);
 
 	/// <summary>
 	/// Contains the implementation details for rendering grids.
@@ -47,14 +63,14 @@ public static partial class ImGuiWidgets
 		/// <param name="items">The items to be displayed in the grid.</param>
 		/// <param name="measureDelegate">The delegate to measure the size of each item.</param>
 		/// <param name="drawDelegate">The delegate to draw each item.</param>
-		public static void Show<T>(IEnumerable<T> items, MeasureGridCell<T> measureDelegate, DrawGridCell<T> drawDelegate)
+		/// <param name="gridOrder">What ordering should grid items use</param>
+		public static void Show<T>(IEnumerable<T> items, MeasureGridCell<T> measureDelegate, DrawGridCell<T> drawDelegate, GridOrder gridOrder)
 		{
 			var itemSpacing = ImGui.GetStyle().ItemSpacing;
 			var itemList = items.ToArray();
 			var itemDimensions = items.Select(i => measureDelegate(i) + itemSpacing).ToArray();
 			var contentRegionAvailable = ImGui.GetContentRegionAvail();
 			int numColumns = 1;
-			bool columnFirst = true;
 
 			while (numColumns <= itemList.Length)
 			{
@@ -62,22 +78,9 @@ public static partial class ImGuiWidgets
 
 				float maxRowWidth = 0f;
 
-				if (columnFirst)
+				switch (gridOrder)
 				{
-					// column first layout
-					for (int i = 0; i < numColumns; i++)
-					{
-						int colOffset = i * numRowsForColumns;
-						var colItems = itemDimensions.Skip(colOffset).Take(numRowsForColumns);
-						if (colItems.Any())
-						{
-							maxRowWidth += colItems.Max(item => item.X) + itemSpacing.X;
-						}
-					}
-				}
-				else
-				{
-					// row first layout
+					case GridOrder.RowMajor:
 					float rowWidth = 0f;
 
 					for (int i = 0; i < itemList.Length; i++)
@@ -90,6 +93,22 @@ public static partial class ImGuiWidgets
 						rowWidth += itemDimensions[i].X + itemSpacing.X;
 						maxRowWidth = Math.Max(maxRowWidth, rowWidth);
 					}
+						break;
+
+					case GridOrder.ColumnMajor:
+						for (int i = 0; i < numColumns; i++)
+						{
+							int colOffset = i * numRowsForColumns;
+							var colItems = itemDimensions.Skip(colOffset).Take(numRowsForColumns);
+							if (colItems.Any())
+							{
+								maxRowWidth += colItems.Max(item => item.X) + itemSpacing.X;
+							}
+				}
+						break;
+
+					default:
+						throw new NotImplementedException($"GridOrder '{gridOrder}' not implemented in ImGuiWidgets.Grid.Show");
 				}
 
 				if (maxRowWidth > contentRegionAvailable.X)
@@ -102,6 +121,34 @@ public static partial class ImGuiWidgets
 				else if (numColumns == itemList.Length)
 				{
 					break;
+				}
+				// ColumnMajor grids are not allowed to have any rows with 2 or more unused cells. If we tried
+				// to draw such a case we would end up displaying items that were meant for the end cells on a
+				// different row which would then cause the grid to be misaligned.
+				// [1] [2] [3]  => [1] [3] [X]
+				// [4]			   [2] [4] 
+				else if (gridOrder == GridOrder.ColumnMajor)
+				{
+					List<int> itemsPerRow = [];
+					int maxItemsPerRow = numColumns;
+					int minItemsPerRow = numColumns - 1;
+
+					int count = 0;
+					for (int i = 0; i < itemList.Length; i++)
+					{
+						count++;
+						if ((i % numColumns == 0) && (i != itemList.Length))
+						{
+							itemsPerRow.Add(count);
+							count = 0;
+						}
+					}
+
+					if (itemsPerRow.Any(c => c < minItemsPerRow))
+					{
+						numColumns--;
+						break;
+					}
 				}
 				numColumns++;
 			}
@@ -122,9 +169,12 @@ public static partial class ImGuiWidgets
 				int column = i % numColumns;
 				int row = i / numColumns;
 
-				int itemIndex = columnFirst
-					? (column * numRows) + row
-					: i;
+				int itemIndex = gridOrder switch
+				{
+					GridOrder.RowMajor => i,
+					GridOrder.ColumnMajor => (column * numRows) + row,
+					_ => throw new NotImplementedException()
+				};
 
 				if (itemIndex < itemList.Length)
 				{
@@ -153,9 +203,12 @@ public static partial class ImGuiWidgets
 				int column = i % numColumns;
 				int row = i / numColumns;
 
-				int itemIndex = columnFirst
-					? (column * numRows) + row
-					: i;
+				int itemIndex = gridOrder switch
+				{
+					GridOrder.RowMajor => i,
+					GridOrder.ColumnMajor => (column * numRows) + row,
+					_ => throw new NotImplementedException()
+				};
 
 				var cellSize = new Vector2(columnWidths[column], rowHeights[row]);
 

--- a/ImGuiWidgets/Grid.cs
+++ b/ImGuiWidgets/Grid.cs
@@ -8,7 +8,7 @@ using ImGuiNET;
 /// </summary>
 public static partial class ImGuiWidgets
 {
-	public static bool EnableGridDebugDraw { get; set; } = true;
+	public static bool EnableGridDebugDraw { get; set; }
 	public enum GridOrder
 	{
 		// Items are displayed in order left to right before dropping to the next row

--- a/ImGuiWidgets/Grid.cs
+++ b/ImGuiWidgets/Grid.cs
@@ -13,14 +13,24 @@ public static partial class ImGuiWidgets
 	{
 		// Items are displayed in order left to right before dropping to the next row
 		// Recommended for when displaying grids of icons
-		// [1] [2] [3]
-		// [4] [5] [6]
+		// [ [1] [2] [3] ]
+		// [ [4] [5] [6] ]
+		// OR
+		// [ [1] [2] [3] [4] [5] ]
+		// [ [6]                 ]
 		RowMajor,
 		// Items are displayed top to bottom before moving to the next column
-		// Note: Only 1 row may show 1 missing item. All other rows will be full.
 		// Recommended when displaying tables of data
-		// [1] [3] [5]
-		// [2] [4] [6]
+		// Note: This will never display uneven rows that have more than 1 item
+		// missing relative to them
+		// [ [1] [3] [5] ]
+		// [ [2] [4] [6] ]
+		// OR
+		// [ [1] [3] [5] ]
+		// [ [2] [4]     ]
+		// NEVER
+		// [ [1] [3] [5] ]
+		// [ [2]         ]
 		ColumnMajor,
 	}
 
@@ -127,21 +137,26 @@ public static partial class ImGuiWidgets
 				// to draw such a case we would end up displaying items that were meant for the end cells on a
 				// different row which would then cause the grid to be misaligned.
 				// [1] [2] [3]  => [1] [3] [X]
-				// [4]			   [2] [4] 
-				else if (gridOrder == GridOrder.ColumnMajor)
+				// [4]			   [2] [4]
+				// Don't check for uneven columns if there is only 1 column as it isn't possible for them
+				// to be uneven (an simplifies the checking logic)
+				else if (gridOrder == GridOrder.ColumnMajor && numColumns != 1)
 				{
-					List<int> itemsPerRow = [];
 					int maxItemsPerRow = numColumns;
 					int minItemsPerRow = numColumns - 1;
 
-					int count = 0;
+					List<int> itemsPerRow = [];
+					int itemCount = 0;
 					for (int i = 0; i < itemList.Length; i++)
 					{
-						count++;
-						if ((i % numColumns == 0) && (i != itemList.Length))
+						itemCount++;
+						// The first item will trigger the end of row log (0 % 1 == 0) and we only get in here
+						// if numColumns > 1 so we can safely ignore the end of row check in that situation
+						bool endOfRow = (i != 0) && (i % numColumns == 0);
+						if (endOfRow)
 						{
-							itemsPerRow.Add(count);
-							count = 0;
+							itemsPerRow.Add(itemCount);
+							itemCount = 0;
 						}
 					}
 

--- a/ImGuiWidgets/Icon.cs
+++ b/ImGuiWidgets/Icon.cs
@@ -9,6 +9,8 @@ using ktsu.ImGuiStyler;
 /// </summary>
 public static partial class ImGuiWidgets
 {
+	public static bool EnableIconDebugDraw { get; set; }
+
 	/// <summary>
 	/// Specifies the alignment of the icon.
 	/// </summary>
@@ -240,12 +242,15 @@ public static partial class ImGuiWidgets
 			ImGui.SetCursorScreenPos(cursorStartPos);
 			ImGui.Dummy(boundingBoxSize);
 			bool isHovered = ImGui.IsItemHovered();
-			if (isHovered)
+			if (isHovered || EnableIconDebugDraw)
 			{
 				uint borderColor = ImGui.GetColorU32(ImGui.GetStyle().Colors[(int)ImGuiCol.Border]);
 				var drawList = ImGui.GetWindowDrawList();
 				drawList.AddRect(cursorStartPos, cursorStartPos + boundingBoxSize, ImGui.GetColorU32(borderColor));
+			}
 
+			if (isHovered)
+			{
 				if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
 				{
 					iconDelegates.OnClick?.Invoke();

--- a/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
+++ b/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
@@ -22,14 +22,15 @@ internal class ImGuiWidgetsDemo
 	private ImGuiPopups.MessageOK MessageOK { get; } = new();
 
 	private List<string> GridStrings { get; } = [];
+	private static int InitialGridSize { get; } = 32;
+	private int gridItemsToShow = InitialGridSize;
 
 	private void OnStart()
 	{
 		DividerContainer.Add(new("Left", 0.25f, ShowLeftPanel));
 		DividerContainer.Add(new("Right", 0.75f, ShowRightPanel));
 
-
-		for (int i = 0; i < 32; i++)
+		for (int i = 0; i < InitialGridSize; i++)
 		{
 			string randomString = $"{i}:";
 			int randomAmount = new Random().Next(2, 32);
@@ -94,6 +95,7 @@ internal class ImGuiWidgetsDemo
 		}
 	}
 
+	private int gridItemsToShow = 32;
 
 	private void ShowRightPanel(float size)
 	{
@@ -115,7 +117,6 @@ internal class ImGuiWidgetsDemo
 		float tilePaddingPx = ImGuiApp.EmsToPx(tilePaddingEms);
 
 		var iconSize = new Vector2(iconWidthPx, iconWidthPx);
-
 
 		if (ImGuiWidgets.Tile("Tile1", tileWidthPx, tilePaddingPx, () =>
 		{
@@ -165,29 +166,22 @@ internal class ImGuiWidgetsDemo
 			ImGuiWidgets.Icon(item, ktsuTexture.TextureId, iconSizePx, Color.White.Value);
 		});
 
-		ImGui.NewLine();
-		ImGui.SeparatorText("Grid, Icon Alignment Vertical");
-		float bigIconSize = iconSizePx * 2;
-		ImGuiWidgets.Grid(GridStrings, i => ImGuiWidgets.CalcIconSize(i, bigIconSize, ImGuiWidgets.IconAlignment.Vertical), (item, cellSize, itemSize) =>
-		{
-			Alignment.CenterWithin(itemSize.X, cellSize.X);
-			ImGuiWidgets.Icon(item, ktsuTexture.TextureId, bigIconSize, Color.White.Value, ImGuiWidgets.IconAlignment.Vertical);
-		});
+		ImGui.SliderInt("Items to show##Vertical", ref gridItemsToShow, 1, GridStrings.Count);
 
-		ImGui.NewLine();
-		ImGui.SeparatorText("Grid, Single Item, Icon Alignment Horizontal");
-		ImGuiWidgets.Grid(GridStrings.Take(1), i => ImGuiWidgets.CalcIconSize(i, iconSizePx), (item, cellSize, itemSize) =>
+		ImGui.SeparatorText("Grid (Column Major) Icon Alignment Horizontal");
+		ImGuiWidgets.Grid(GridStrings.Take(gridItemsToShow), i => ImGuiWidgets.CalcIconSize(i, iconSizePx), (item, cellSize, itemSize) =>
 		{
 			ImGuiWidgets.Icon(item, ktsuTexture.TextureId, iconSizePx, Color.White.Value);
-		});
+		}, ImGuiWidgets.GridOrder.ColumnMajor);
 
 		ImGui.NewLine();
-		ImGui.SeparatorText("Grid, Single Item, Icon Alignment Vertical");
-		ImGuiWidgets.Grid(GridStrings.Take(1), i => ImGuiWidgets.CalcIconSize(i, bigIconSize, ImGuiWidgets.IconAlignment.Vertical), (item, cellSize, itemSize) =>
+		ImGui.SeparatorText("Grid (Row Major) Icon Alignment Vertical");
+		float bigIconSize = iconSizePx * 2;
+		ImGuiWidgets.Grid(GridStrings.Take(gridItemsToShow), i => ImGuiWidgets.CalcIconSize(i, bigIconSize, ImGuiWidgets.IconAlignment.Vertical), (item, cellSize, itemSize) =>
 		{
 			Alignment.CenterWithin(itemSize.X, cellSize.X);
 			ImGuiWidgets.Icon(item, ktsuTexture.TextureId, bigIconSize, Color.White.Value, ImGuiWidgets.IconAlignment.Vertical);
-		});
+		}, ImGuiWidgets.GridOrder.RowMajor);
 
 		MessageOK.ShowIfOpen();
 	}

--- a/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
+++ b/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
@@ -95,8 +95,6 @@ internal class ImGuiWidgetsDemo
 		}
 	}
 
-	private int gridItemsToShow = 32;
-
 	private void ShowRightPanel(float size)
 	{
 		ImGui.Text("Right Divider Zone");
@@ -160,14 +158,7 @@ internal class ImGuiWidgetsDemo
 		float iconSizePx = ImGuiApp.EmsToPx(2.5f);
 
 		ImGui.NewLine();
-		ImGui.SeparatorText("Grid, Icon Alignment Horizontal");
-		ImGuiWidgets.Grid(GridStrings, i => ImGuiWidgets.CalcIconSize(i, iconSizePx), (item, cellSize, itemSize) =>
-		{
-			ImGuiWidgets.Icon(item, ktsuTexture.TextureId, iconSizePx, Color.White.Value);
-		});
-
-		ImGui.SliderInt("Items to show##Vertical", ref gridItemsToShow, 1, GridStrings.Count);
-
+		ImGui.SliderInt("Grid items to show", ref gridItemsToShow, 1, GridStrings.Count);
 		ImGui.SeparatorText("Grid (Column Major) Icon Alignment Horizontal");
 		ImGuiWidgets.Grid(GridStrings.Take(gridItemsToShow), i => ImGuiWidgets.CalcIconSize(i, iconSizePx), (item, cellSize, itemSize) =>
 		{

--- a/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
+++ b/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
@@ -158,7 +158,19 @@ internal class ImGuiWidgetsDemo
 		float iconSizePx = ImGuiApp.EmsToPx(2.5f);
 
 		ImGui.NewLine();
+
+		bool showGridDebug = ImGuiWidgets.EnableGridDebugDraw;
+		if (ImGui.Checkbox("Show Grid Debug", ref showGridDebug))
+		{
+			ImGuiWidgets.EnableGridDebugDraw = showGridDebug;
+		}
+		bool showIconDebug = ImGuiWidgets.EnableIconDebugDraw;
+		if (ImGui.Checkbox("Show Icon Debug", ref showIconDebug))
+		{
+			ImGuiWidgets.EnableIconDebugDraw = showIconDebug;
+		}
 		ImGui.SliderInt("Grid items to show", ref gridItemsToShow, 1, GridStrings.Count);
+
 		ImGui.SeparatorText("Grid (Column Major) Icon Alignment Horizontal");
 		ImGuiWidgets.Grid(GridStrings.Take(gridItemsToShow), i => ImGuiWidgets.CalcIconSize(i, iconSizePx), (item, cellSize, itemSize) =>
 		{


### PR DESCRIPTION
Added options to display the full extents of grid cells and icons. Useful for debugging when things don't align correctly.