### PR TITLE
Fix for grid double counting item spacing, yet only using a single during column count calculation

### DIFF
--- a/ImGuiWidgets/Grid.cs
+++ b/ImGuiWidgets/Grid.cs
@@ -124,7 +124,7 @@ public static partial class ImGuiWidgets
 								rowWidth = 0f;
 							}
 
-							rowWidth += itemDimensions[i].X + itemSpacing.X;
+							rowWidth += itemDimensions[i].X;
 							maxRowWidth = Math.Max(maxRowWidth, rowWidth);
 						}
 						break;
@@ -136,7 +136,7 @@ public static partial class ImGuiWidgets
 							var colItems = itemDimensions.Skip(colOffset).Take(numRowsForColumns).ToArray();
 							if (colItems.Length != 0)
 							{
-								maxRowWidth += colItems.Max(item => item.X) + itemSpacing.X;
+								maxRowWidth += colItems.Max(item => item.X);
 							}
 						}
 						break;


### PR DESCRIPTION
- When itemDimensions are calculated it is the itemWidth + itemSpacing.X.
- When we render we advance the cursor by the current itemDimensions.
- When calculating how many columns we can support we take the itemDimensions and add itemSpacing.X for each item in the row.

When calculating the rowWidth we shouldn't add any itemSpacing as it is already accounted for in the itemDimensions.

This is most notable when the grid is in left aligned mode (coming soon)