### PR TITLE
Fix for SetPos ImGui assert

### DIFF
--- a/ImGuiWidgets/Grid.cs
+++ b/ImGuiWidgets/Grid.cs
@@ -234,6 +234,9 @@ public static partial class ImGuiWidgets
 			}
 
 			var marginTopLeftCursor = ImGui.GetCursorScreenPos();
+			var gridSize = new Vector2(contentRegionAvailable.X, rowHeights.Sum(h => h));
+			ImGui.Dummy(gridSize);
+			ImGui.SetCursorScreenPos(marginTopLeftCursor);
 
 			int numCells = numColumns * numRows;
 			for (int i = 0; i < numCells; i++)
@@ -270,6 +273,9 @@ public static partial class ImGuiWidgets
 				}
 				ImGui.SetCursorScreenPos(advance);
 			}
+
+			ImGui.SetCursorScreenPos(marginTopLeftCursor + gridSize);
+			ImGui.Dummy(new Vector2(0, 0));
 		}
 	}
 }


### PR DESCRIPTION
By setting the cursor to the bottom right of the grid and making a 0 sized dummy it results in the cursor position being advanced to the new line and the CursorMaxPos internal state being correct so it doesn't trigger the assert.