### PR TITLE
Simplify the assert fix

### DIFF
--- a/ImGuiWidgets/Grid.cs
+++ b/ImGuiWidgets/Grid.cs
@@ -234,9 +234,8 @@ public static partial class ImGuiWidgets
 			}
 
 			var marginTopLeftCursor = ImGui.GetCursorScreenPos();
-			var gridSize = new Vector2(contentRegionAvailable.X, rowHeights.Sum(h => h));
-			ImGui.Dummy(gridSize);
-			ImGui.SetCursorScreenPos(marginTopLeftCursor);
+			float gridWidth = contentRegionAvailable.X;
+			float gridHeight = rowHeights.Sum(h => h);
 
 			int numCells = numColumns * numRows;
 			for (int i = 0; i < numCells; i++)
@@ -274,8 +273,8 @@ public static partial class ImGuiWidgets
 				ImGui.SetCursorScreenPos(advance);
 			}
 
-			ImGui.SetCursorScreenPos(marginTopLeftCursor + gridSize);
-			ImGui.Dummy(new Vector2(0, 0));
+			ImGui.SetCursorScreenPos(marginTopLeftCursor + new Vector2(gridWidth, 0f));
+			ImGui.Dummy(new Vector2(0, gridHeight));
 		}
 	}
 }


### PR DESCRIPTION
- Instead of creating a dummy up front and moving the cursor more times we can simply render everything as we did before and at the end move the cursor to the top right of the grid and make a dummy the height of the grid which will leave the cursor on the new line
- This also theoretically supports ImGui.SameLine if the grid was to ever not span the full width